### PR TITLE
Add getBukkitSender API

### DIFF
--- a/src/main/java/me/lucko/commodore/Commodore.java
+++ b/src/main/java/me/lucko/commodore/Commodore.java
@@ -30,6 +30,7 @@ import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 
 import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
 import org.bukkit.command.PluginCommand;
 
 import java.util.Collection;
@@ -53,6 +54,21 @@ public interface Commodore {
      * @return the command dispatcher
      */
     CommandDispatcher getDispatcher();
+
+
+    /**
+     * Gets the CommandSender associated with the passed CommandWrapperListener.
+     *
+     * <p>Minecraft calls the brigadier with an instance of CommandWrapperListener,
+     * which cannot be accessed by non-nms using plugins. Therefore, this method takes
+     * an Object instead of a concrete class. The only type actually accepted is those
+     * from the <S> type provided by Minecraft. This can be used for checking whether
+     * a CommandSender can execute a given node.</p>
+     *
+     * @param commandWrapperListener the CommandWrapperListener instance provided by NMS.
+     * @return the CommandWrapperListener wrapped as a CommandSender.
+     */
+    CommandSender getBukkitSender(Object commandWrapperListener);
 
     /**
      * Gets a list of all nodes registered to the {@link CommandDispatcher} by

--- a/src/main/java/me/lucko/commodore/CommodoreImpl.java
+++ b/src/main/java/me/lucko/commodore/CommodoreImpl.java
@@ -33,6 +33,7 @@ import com.mojang.brigadier.tree.LiteralCommandNode;
 
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.server.ServerLoadEvent;
@@ -56,6 +57,9 @@ final class CommodoreImpl implements Commodore {
     // nms.MinecraftServer#getCommandDispatcher method
     private static final Method GET_COMMAND_DISPATCHER_METHOD;
 
+    // nms.CommandListenerWrapper#getBukkitSender method
+    private static final Method GET_BUKKIT_SENDER_METHOD;
+
     // nms.CommandDispatcher#getDispatcher (obfuscated) method
     private static final Method GET_BRIGADIER_DISPATCHER_METHOD;
 
@@ -64,6 +68,7 @@ final class CommodoreImpl implements Commodore {
 
     // ArgumentCommandNode#customSuggestions field
     private static final Field CUSTOM_SUGGESTIONS_FIELD;
+
 
     static {
         try {
@@ -74,6 +79,10 @@ final class CommodoreImpl implements Commodore {
             Class<?> minecraftServer = ReflectionUtil.nmsClass("MinecraftServer");
             GET_COMMAND_DISPATCHER_METHOD = minecraftServer.getDeclaredMethod("getCommandDispatcher");
             GET_COMMAND_DISPATCHER_METHOD.setAccessible(true);
+
+            Class<?> commandListenerWrapper = ReflectionUtil.nmsClass("CommandListenerWrapper");
+            GET_BUKKIT_SENDER_METHOD = commandListenerWrapper.getDeclaredMethod("getBukkitSender");
+            GET_BUKKIT_SENDER_METHOD.setAccessible(true);
 
             Class<?> commandDispatcher = ReflectionUtil.nmsClass("CommandDispatcher");
             Method getBrigadierDispatcherMethod = null;
@@ -127,6 +136,18 @@ final class CommodoreImpl implements Commodore {
         } catch (IllegalAccessException | InvocationTargetException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Override
+    public CommandSender getBukkitSender(Object commandWrapperListener)
+    {
+        Objects.requireNonNull(commandWrapperListener, "commandWrapperListener");
+        try {
+            return (CommandSender) GET_BUKKIT_SENDER_METHOD.invoke(commandWrapperListener);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+
     }
 
     @Override


### PR DESCRIPTION
Adds a getBukkitSender API function to provide translation between vanilla's CommandWrapperListener and Bukkit's CommandSender.

The main targeted use case of this method is be ArgumentBuilder#requires. When the command tree is traversed by vanilla, the \<S\> type is CommandWrapperListener, but plugins cannot do anything with that since they are not aware of that class. This method allows conversion of that object to a CommandSender so that normal Bukkit calls can be performed (such as checking for permissions or checking whether the executer isOp).

Tested with my own plugin, and seems to work like a charm. For example:
`builder.requires((sender) -> commodore.getBukkitSender(sender).isOp());`
will be a node only sent to players that are op.